### PR TITLE
貸出一覧、貸出登録機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,14 +1,28 @@
 package jp.co.metateam.library.controller;
 
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.validation.BindingResult;
 
 import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
+
+import jakarta.validation.Valid;
+import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.RentalManageDto;
+import jp.co.metateam.library.model.Stock; 
+import jp.co.metateam.library.model.Account; 
+import jp.co.metateam.library.model.AccountDto;
+
+import jp.co.metateam.library.values.RentalStatus;
 
 /**
  * 貸出管理関連クラスß
@@ -30,6 +44,7 @@ public class RentalManageController {
         this.accountService = accountService;
         this.rentalManageService = rentalManageService;
         this.stockService = stockService;
+
     }
 
     /**
@@ -40,11 +55,46 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
-
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
         // 貸出一覧画面に渡すデータをmodelに追加
-
+        model.addAttribute("rentalManageList", rentalManageList);
         // 貸出一覧画面に遷移
-        return "";
+        return "/rental/index";
     }
 
+    @GetMapping("/rental/add")
+    public String add(Model model) {
+        List<Stock> stockList = this.stockService.findAll();
+        List<Account> accounts = this.accountService.findAll();
+
+        model.addAttribute("stockList", stockList);
+        model.addAttribute("rentalStatus", RentalStatus.values());
+        model.addAttribute("accounts", accounts);
+
+        if (!model.containsAttribute("rentalManageDto")) {
+            model.addAttribute("rentalManageDto", new RentalManageDto());
+        }
+
+        return "rental/add";
+    }
+
+    @PostMapping("/rental/add")
+    public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+        try {
+            if (result.hasErrors()) {
+                throw new Exception("Validation error.");
+            }
+            // 登録処理
+            this.rentalManageService.save(rentalManageDto);
+
+            return "redirect:/rental/index";
+        } catch (Exception e) {
+            log.error(e.getMessage());
+
+            ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+            ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+
+            return "redirect:/rental/add";
+        }
+    }
 }

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -2,6 +2,7 @@ package jp.co.metateam.library.model;
 
 import java.util.Date;
 import java.sql.Timestamp;
+import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/resources/templates/common.html
+++ b/src/main/resources/templates/common.html
@@ -57,6 +57,17 @@
                     <a class="menu_link" th:href="@{/stock/add}">在庫登録</a>
                 </div>
             </details>
+            <div class="menu_item">
+                <a class="menu_link" th:href="@{/stock/calendar}"><img th:src="@{/images/icons/calendar.png}" alt="calendar"/>在庫カレンダー</a>
+            </div>
+            <details class="menu_inner">
+                <summary class="menu_item">
+                    <a class="menu_link" th:href="@{/rental/index}"><img th:src="@{/images/icons/rental.png}" alt="book" />貸出一覧</a>
+                </summary>
+                <div class="menu_item second">
+                    <a class="menu_link" th:href="@{/rental/add}">貸出登録</a>
+                </div>
+            </details>
         </div>
     </div>
 


### PR DESCRIPTION
### 概要 
・貸出一覧画面と貸出登録画面の追加 ・貸出一覧画面と貸出登録画面を追加しました。貸出登録画面は社員番号、在庫管理番号、貸出ステータスがプルダウンで選択できるようになっています。
### テスト証跡 
・貸出登録画面でプルダウンが選択されるか、保存がされるかの動作確認を行っていただきたいです。