### PR TITLE
在庫カレンダー機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -71,8 +71,9 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(@RequestParam("stockId") String stockIds,
-            @RequestParam("expectedRentalOn") @DateTimeFormat(pattern = "yyyy-MM-dd") Date specifiedDate, Model model) {
+    public String add(@RequestParam(required = false) String stockId,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date expectedRentalOn,
+            Model model) {
 
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
@@ -85,13 +86,9 @@ public class RentalManageController {
 
             RentalManageDto rentalManageDto = new RentalManageDto();
             // データセット するかしないか
-            if (stockIds != null) {
-                // 在庫管理番号をセット
-                rentalManageDto.setStockId(stockIds);
-            }
-            if (specifiedDate != null) {
-                // 貸出予定日をセット
-                rentalManageDto.setExpectedRentalOn(specifiedDate);
+            if (stockId != null && expectedRentalOn != null) {
+                rentalManageDto.setStockId(stockId);
+                rentalManageDto.setExpectedRentalOn(expectedRentalOn);
             }
 
             model.addAttribute("rentalManageDto", rentalManageDto);

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,13 +12,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.Stock;
-import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.service.AccountService;
 import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.service.RentalManageService;
@@ -26,8 +27,6 @@ import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.values.RentalStatus;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.bind.annotation.PathVariable;
-import jp.co.metateam.library.constants.Constants;
-import jp.co.metateam.library.repository.RentalManageRepository;
 import java.util.Optional;
 
 /**
@@ -72,7 +71,9 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto) {
+    public String add(@RequestParam("stockId") String stockIds,
+            @RequestParam("expectedRentalOn") @DateTimeFormat(pattern = "yyyy-MM-dd") Date specifiedDate, Model model) {
+
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
 
@@ -81,7 +82,20 @@ public class RentalManageController {
         model.addAttribute("accounts", accounts);
 
         if (!model.containsAttribute("rentalManageDto")) {
-            model.addAttribute("rentalManageDto", new RentalManageDto());
+
+            RentalManageDto rentalManageDto = new RentalManageDto();
+            // データセット するかしないか
+            if (stockIds != null) {
+                // 在庫管理番号をセット
+                rentalManageDto.setStockId(stockIds);
+            }
+            if (specifiedDate != null) {
+                // 貸出予定日をセット
+                rentalManageDto.setExpectedRentalOn(specifiedDate);
+            }
+
+            model.addAttribute("rentalManageDto", rentalManageDto);
+
         }
 
         return "rental/add";
@@ -89,9 +103,23 @@ public class RentalManageController {
 
     @PostMapping("/rental/add")
     public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result,
-            RedirectAttributes ra, Model model) {
+            RedirectAttributes ra) {
         // バリデーションチェック
         try {
+            // 日付Format
+            String formatError = rentalManageDto.validDateFormat(rentalManageDto);
+            if (formatError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", formatError));
+                throw new RuntimeException(formatError);
+            }
+
+            // 貸出予定日＜返却予定日
+            String orderDateError = rentalManageDto.orderRentalDate(rentalManageDto);
+            if (orderDateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", orderDateError));
+                throw new RuntimeException(orderDateError);
+            }
+
             // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
             String stockId = rentalManageDto.getStockId();
             Integer status = rentalManageDto.getStatus();
@@ -105,15 +133,15 @@ public class RentalManageController {
 
                     if (!(stockaddcount == rentaladdcount)) {
                         String rentaladdError = "この期間は貸出できません。";
-                        result.addError(new FieldError("rentalmanageDto", "expectedRentalOn", rentaladdError));
-                        result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", rentaladdError));
+                        result.addError(new FieldError("rentalManageDto", "expectedRentalOn", rentaladdError));
+                        result.addError(new FieldError("rentalManageDto", "expectedReturnOn", rentaladdError));
                     }
                 }
             }
-
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
+
             // 登録処理
             this.rentalManageService.save(rentalManageDto);
 
@@ -121,23 +149,11 @@ public class RentalManageController {
         } catch (Exception e) {
             log.error(e.getMessage());
 
-            rentalManageDto.setEmployeeId(rentalManageDto.getEmployeeId());
-            rentalManageDto.setExpectedRentalOn(rentalManageDto.getExpectedRentalOn());
-            rentalManageDto.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
-            rentalManageDto.setStatus(rentalManageDto.getStatus());
-            rentalManageDto.setStockId(rentalManageDto.getStockId());
-
-            List<Stock> stockList = this.stockService.findAll();
-            List<Account> accounts = this.accountService.findAll();
-
-            model.addAttribute("rentalStatus", RentalStatus.values());
-            model.addAttribute("stockList", stockList);
-            model.addAttribute("accounts", accounts);
-
             ra.addFlashAttribute("rentalManageDto", rentalManageDto);
             ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
 
-            return "/rental/add";
+            return "redirect:/rental/add";
+
         }
     }
 
@@ -179,9 +195,23 @@ public class RentalManageController {
         try {
             // 変更前の貸出情報を取得
             RentalManage rentalManage = this.rentalManageService.findById(Long.valueOf(id));
-            // 変更前と変更後の貸出ステータスを取得
-            Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
+
+            // 日付Format
+            String formatError = rentalManageDto.validDateFormat(rentalManageDto);
+            if (formatError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", formatError));
+                throw new RuntimeException(formatError);
+            }
+
+            // 貸出予定日＜返却予定日
+            String orderDateError = rentalManageDto.orderRentalDate(rentalManageDto);
+            if (orderDateError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", orderDateError));
+                throw new RuntimeException(orderDateError);
+            }
+
             // Optionalが空でない場合のみエラーを処理する
+            Optional<String> validErrorOptional = rentalManageDto.isStatusError(rentalManage.getStatus());
             validErrorOptional.ifPresent(validError -> {
                 if (!validError.isEmpty()) {
                     result.addError(new FieldError("rentalmanageDto", "status", validError));
@@ -189,18 +219,28 @@ public class RentalManageController {
                 }
             });
 
+            // ステータスと日付チェック
+            String DateError = rentalManageDto.isDateError(rentalManage, rentalManageDto);
+            if (DateError != null) {
+                result.addError(new FieldError("rentalmanageDto", "expectedReturnOn", DateError));
+                throw new RuntimeException(DateError);
+            }
+
             // 貸出可否チェック(リポジトリ→サービスでチェック→その結果をここで呼び出す)
             String stockId = rentalManageDto.getStockId();
-            Long ID = rentalManage.getId();
+            Long rentalId = rentalManage.getId();
             Integer status = rentalManageDto.getStatus();
 
-            if (status == 0 || status == 1) {
-                Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId, ID);
+            if (status == RentalStatus.RENT_WAIT.getValue() || status == RentalStatus.RENTALING.getValue()) {
+                Long stockcount = this.rentalManageService.countByStockIdAndStatusIn(stockId, rentalId);
 
                 if (!(stockcount == 0)) {
+
                     Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
                     Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
-                    Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId, ID,
+
+                    Long rentalcount = this.rentalManageService.countByStockIdAndStatusInAndExpectedDates(stockId,
+                            rentalId,
                             expectedReturnOn, expectedRentalOn);
 
                     if (!(stockcount == rentalcount)) {
@@ -220,7 +260,9 @@ public class RentalManageController {
 
             return "redirect:/rental/index";
 
-        } catch (Exception e) {
+        } catch (
+
+        Exception e) {
             log.error(e.getMessage());
 
             // 変更前の貸出情報を取得

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -1,6 +1,8 @@
 package jp.co.metateam.library.controller;
 
 import java.time.LocalDate;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
@@ -41,7 +44,7 @@ public class StockController {
 
     @GetMapping("/stock/index")
     public String index(Model model) {
-        List <Stock> stockList = this.stockService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
 
         model.addAttribute("stockList", stockList);
 
@@ -113,7 +116,8 @@ public class StockController {
     }
 
     @PostMapping("/stock/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result, RedirectAttributes ra) {
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result,
+            RedirectAttributes ra) {
         try {
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
@@ -132,23 +136,27 @@ public class StockController {
     }
 
     @GetMapping("/stock/calendar")
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
+            Model model) {
 
         LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
+        // 表示する年月を取得
         Integer targetYear = year == null ? today.getYear() : year;
+        // カレンダーの表示範囲の開始日を計算
         Integer targetMonth = today.getMonthValue();
 
+        // 表示される月の日数を計算
         LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
         Integer daysInMonth = startDate.lengthOfMonth();
 
+        // カレンダーの曜日と在庫データを生成
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<List<CalendarDto>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
-
         model.addAttribute("stocks", stocks);
 
         return "stock/calendar";

--- a/src/main/java/jp/co/metateam/library/model/BookMstDto.java
+++ b/src/main/java/jp/co/metateam/library/model/BookMstDto.java
@@ -2,8 +2,6 @@ package jp.co.metateam.library.model;
 
 import java.security.Timestamp;
 
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,15 +11,15 @@ import lombok.Setter;
 @Getter
 @Setter
 public class BookMstDto {
-    
-    private Long id; 
-    
+
+    private Long id;
+
     private String isbn;
 
     private String title;
-    
+
     private long stockCount;
-    
+
     private Timestamp deletedAt;
 
     private BookMst bookMst;

--- a/src/main/java/jp/co/metateam/library/model/RentalManage.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManage.java
@@ -2,7 +2,6 @@ package jp.co.metateam.library.model;
 
 import java.util.Date;
 import java.sql.Timestamp;
-import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -3,6 +3,9 @@ package jp.co.metateam.library.model;
 import jp.co.metateam.library.values.RentalStatus;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 
@@ -63,6 +66,61 @@ public class RentalManageDto {
         }
         return Optional.empty();
 
+    }
+
+    // 日付チェック
+    public String isDateError(RentalManage rentalManage, RentalManageDto rentalManageDto) {
+        // 現在の日時
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo"));
+
+        // status 古いのと新しいの
+        Integer prestatus = rentalManage.getStatus();
+        Integer poststatus = rentalManageDto.getStatus();
+
+        // expectedを二つ
+        LocalDate expectedRentalOn = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+        LocalDate expectedReturnOn = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault())
+                .toLocalDate();
+
+        // if文・貸出待ち→貸出中、・貸出中→返却済み
+        if (prestatus == 0 && poststatus == 1) {
+            if (!expectedRentalOn.equals(nowDate)) {
+                return "貸出予定日は現在の日付を選択してください。";
+            }
+        }
+
+        if (prestatus == 1 && poststatus == 2) {
+            if (!expectedReturnOn.equals(nowDate)) {
+                return "返却予定日は現在の日付を選択してください。";
+            }
+        }
+        return null;
+    }
+
+    // 貸出予定日＜返却予定日
+    public String orderRentalDate(RentalManageDto rentalManageDto) {
+        Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+        Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+
+        if (!expectedRentalOn.before(expectedReturnOn)) {
+            return "返却予定日は貸出予定日より後の日付を入力してください.";
+        }
+        return null;
+    }
+
+    // 日付Format
+    public String validDateFormat(RentalManageDto rentalManageDto) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+
+        String expectedRentalOnStr = sdf.format(rentalManageDto.getExpectedRentalOn());
+        String expectedReturnOnStr = sdf.format(rentalManageDto.getExpectedReturnOn());
+
+        if (!expectedRentalOnStr.matches("\\d{4}/\\d{2}/\\d{2}")
+                || !expectedReturnOnStr.matches("\\d{4}/\\d{2}/\\d{2}")) {
+            return "yyyy/mm/ddのフォーマットで入力してください";
+        }
+        return null;
     }
 
 }

--- a/src/main/java/jp/co/metateam/library/model/calendarDto.java
+++ b/src/main/java/jp/co/metateam/library/model/calendarDto.java
@@ -1,0 +1,25 @@
+package jp.co.metateam.library.model;
+
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 在庫管理DTO
+ */
+@Getter
+@Setter
+public class CalendarDto {
+
+    private String title;
+
+    private String stockId;
+
+    private Date expectedRentalOn;
+
+    private Long countAvailableRental;
+
+    private Long stockCount;
+
+}

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -22,7 +22,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
         long countByStockIdAndStatus(String stockId);
 
         @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.expectedReturnOn < ?2  AND rm.expectedRentalOn > ?3")
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND (rm.expectedReturnOn < ?2  OR rm.expectedRentalOn > ?3)")
         long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedRentalOn, Date expectedReturnOn);
 
         @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
@@ -30,7 +30,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
         long countByStockIdAndStatusIn(String stockId, Long ID);
 
         @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.id != ?2 AND rm.expectedReturnOn < ?3  OR rm.expectedRentalOn > ?4")
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.id != ?2 AND (rm.expectedReturnOn < ?3  OR rm.expectedRentalOn > ?4)")
         long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
                         Date expectedReturnOn);
 
@@ -41,7 +41,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
         Long countBySpecifiedDateRentals(String title, Date specifiedDate);
 
         // タイトル、在庫管理番号
-        @Query(value = "SELECT s.id FROM stocks s Left JOIN rental_manage rm  ON s.id = rm.stock_id JOIN book_mst bm ON s.book_id = bm.id WHERE s.status = 0 AND bm.title= :title AND (rm.stock_id is null OR rm.expected_rental_on > :day OR rm.expected_return_on < :day OR rm.status = 3)", nativeQuery = true)
-        List<String> selectByStockId(@Param("title") String title, @Param("day") Date specifiedDate);
+        @Query(value = "SELECT s.id FROM stocks s Left JOIN rental_manage rm  ON s.id = rm.stock_id JOIN book_mst bm ON s.book_id = bm.id WHERE s.status = 0 AND bm.title= ?1 AND (rm.stock_id is null OR rm.expected_rental_on > ?2 OR rm.expected_return_on < ?2 OR rm.status = 3)", nativeQuery = true)
+        List<String> selectByStockId(String title, Date specifiedDate);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -7,43 +7,41 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
-    List<RentalManage> findAll();
+        List<RentalManage> findAll();
 
-    Optional<RentalManage> findById(Long id);
+        Optional<RentalManage> findById(Long id);
 
-    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) ")
-    long countByStockIdAndStatus(String stockId);
+        @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1  AND rm.status IN (0, 1) ")
+        long countByStockIdAndStatus(String stockId);
 
-    @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.expectedReturnOn < ?2 " +
-            " AND rm.expectedRentalOn > ?3")
-    long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedReturnOn, Date expectedRentalOn);
+        @Query // 登録の在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.expectedReturnOn < ?2  AND rm.expectedRentalOn > ?3")
+        long countByStockIdAndStatusAndExpectedDates(String stockId, Date expectedRentalOn, Date expectedReturnOn);
 
-    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.id != ?2 ")
-    long countByStockIdAndStatusIn(String stockId, Long ID);
+        @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1)  AND rm.id != ?2 ")
+        long countByStockIdAndStatusIn(String stockId, Long ID);
 
-    @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
-    ("SELECT COUNT(rm) FROM RentalManage rm " +
-            " WHERE rm.stock.id = ?1 " +
-            " AND rm.status IN (0, 1) " +
-            " AND rm.id != ?2 " +
-            " AND rm.expectedReturnOn < ?3 " +
-            " OR rm.expectedRentalOn > ?4")
-    long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
-            Date expectedReturnOn);
+        @Query // 変更する在庫の貸出待ち、貸出中をDBから持ってきて、期間が被っていない本の数を取得
+        ("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.id != ?2 AND rm.expectedReturnOn < ?3  OR rm.expectedRentalOn > ?4")
+        long countByStockIdAndStatusInAndExpectedDates(String stockId, Long ID, Date expectedRentalOn,
+                        Date expectedReturnOn);
+
+        @Query // タイトル別、日ごとの貸し出されている冊数
+        (value = "SELECT COUNT(*) FROM rental_manage rm INNER JOIN stocks s ON rm.stock_id = s.id INNER JOIN book_mst bm ON s.book_id = bm.id "
+                        +
+                        " WHERE bm.title = ?1 AND (rm.expected_rental_on <= ?2 AND rm.expected_return_on >= ?2)", nativeQuery = true)
+        Long countBySpecifiedDateRentals(String title, Date specifiedDate);
+
+        // タイトル、在庫管理番号
+        @Query(value = "SELECT s.id FROM stocks s Left JOIN rental_manage rm  ON s.id = rm.stock_id JOIN book_mst bm ON s.book_id = bm.id WHERE s.status = 0 AND bm.title= :title AND (rm.stock_id is null OR rm.expected_rental_on > :day OR rm.expected_return_on < :day OR rm.status = 3)", nativeQuery = true)
+        List<String> selectByStockId(@Param("title") String title, @Param("day") Date specifiedDate);
+
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -4,20 +4,26 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
-    
+
     List<Stock> findAll();
 
     List<Stock> findByDeletedAtIsNull();
 
     List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
 
-	Optional<Stock> findById(String id);
-    
-    List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+    Optional<Stock> findById(String id);
+
+    List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
+
+    // タイトル、在庫数
+    @Query("SELECT s.bookMst.title, COUNT(s) FROM Stock s JOIN s.bookMst WHERE s.status = 0 GROUP BY s.bookMst.title")
+    List<Object[]> countByTotalStockPerTitle();
+
 }

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import io.micrometer.common.util.StringUtils;
 import jp.co.metateam.library.constants.Constants;
@@ -23,9 +22,9 @@ public class BookMstService {
 
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
-    
+
     @Autowired
-    public BookMstService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public BookMstService(BookMstRepository bookMstRepository, StockRepository stockRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
     }
@@ -37,7 +36,7 @@ public class BookMstService {
     public Optional<BookMst> findById(Long id) {
         return this.bookMstRepository.findById(id);
     }
-    
+
     public List<BookMstDto> findAvailableWithStockCount() {
         List<BookMst> books = this.bookMstRepository.findAll();
         List<BookMstDto> bookMstDtoList = new ArrayList<BookMstDto>();
@@ -46,7 +45,8 @@ public class BookMstService {
         // FIXME: 現状は書籍ID毎にDBに問い合わせている。一度のSQLで完了させたい。
         for (int i = 0; i < books.size(); i++) {
             BookMst book = books.get(i);
-            List<Stock> stockCount = this.stockRepository.findByBookMstIdAndStatus(book.getId(), Constants.STOCK_AVAILABLE);
+            List<Stock> stockCount = this.stockRepository.findByBookMstIdAndStatus(book.getId(),
+                    Constants.STOCK_AVAILABLE);
             BookMstDto bookMstDto = new BookMstDto();
             bookMstDto.setId(book.getId());
             bookMstDto.setIsbn(book.getIsbn());
@@ -57,7 +57,7 @@ public class BookMstService {
 
         return bookMstDtoList;
     }
-    
+
     @Transactional
     public void save(BookMstDto bookMstDto) {
         try {
@@ -72,8 +72,6 @@ public class BookMstService {
             throw e;
         }
     }
-    
-   
 
     @Transactional
     public void update(Long id, BookMstDto bookMstDto) throws Exception {
@@ -109,23 +107,4 @@ public class BookMstService {
         }
         return false;
     }
-
-    // public boolean isValidTitle(String title, RedirectAttributes ra) {
-    //     if (StringUtils.isEmpty(title)) {
-    //         ra.addFlashAttribute("errTitle", "書籍タイトルは必須");
-    //         return true;
-    //     }
-    //     return false;
-    // }
-
-    // public boolean isValidIsbn(String isbn, RedirectAttributes ra) {
-    //     if (StringUtils.isEmpty(isbn) || isbn.length() != 13) {
-    //         ra.addFlashAttribute("errISBN", "ISBNは13文字で入力してください");
-    //         return true;
-    //     }
-    //     return false;
-    // }
 }
-
-
-

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -112,6 +112,9 @@ public class RentalManageService {
         return rentalManage;
     }
 
+    // 現在日時取得
+    Date date = new Date();
+
     @Transactional
     public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
         try {

--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -9,6 +9,7 @@
     max-width: 1200px;
     overflow: scroll;
 }
+
 #calendar_table {
     width: 100%;
     border-collapse: collapse;
@@ -34,4 +35,12 @@
 #calendar_table tr.days th {
     padding: 5px;
     font-size: 14px;
+}
+
+.saturday {
+    color: blue;
+}
+
+.sunday {
+    color: red;
 }

--- a/src/main/resources/static/js/rental/add.js
+++ b/src/main/resources/static/js/rental/add.js
@@ -1,29 +1,29 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedReturnOn").attr("min", date);
 }
 
 
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    //setExpectedRentalOn();
+    //setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {

--- a/src/main/resources/static/js/rental/edit.js
+++ b/src/main/resources/static/js/rental/edit.js
@@ -1,34 +1,34 @@
 function dateFormat(today, format) {
     format = format.replace("YYYY", today.getFullYear());
-    format = format.replace("MM", ("0"+(today.getMonth() + 1)).slice(-2));
-    format = format.replace("DD", ("0"+ today.getDate()).slice(-2));
+    format = format.replace("MM", ("0" + (today.getMonth() + 1)).slice(-2));
+    format = format.replace("DD", ("0" + today.getDate()).slice(-2));
     return format;
 }
 
 function setExpectedRentalOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedRentalOn").attr("min", date);
 }
 
 function setExpectedReturnOn() {
-    const date = dateFormat(new Date(),'YYYY-MM-DD');
+    const date = dateFormat(new Date(), 'YYYY-MM-DD');
     $("#expectedReturnOn").attr("min", date);
 }
 
 
-$(function() {
+$(function () {
     // 各日付の最小値を指定（登録日当日の日付）
-    // setExpectedRentalOn();
-    // setExpectedReturnOn();
+    //setExpectedRentalOn();
+    //setExpectedReturnOn();
 
     // 貸出予定日が変更された場合、返却予定日の最小値を変更
     // 貸出予定日 =< 返却予定日 となるようにする
-    $("#expectedRentalOn").on("change", function(){
+    $("#expectedRentalOn").on("change", function () {
         let value = $(this).val();
         $("#expectedReturnOn").val(null);
         if (value === null) {
-            // setExpectedRentalOn();
-            // setExpectedReturnOn();
+            //setExpectedRentalOn();
+            //setExpectedReturnOn();
         } else {
             $("#expectedReturnOn").attr("min", $(this).val());
         }

--- a/src/main/resources/templates/rental/add.html
+++ b/src/main/resources/templates/rental/add.html
@@ -20,7 +20,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
+                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post"
+                    novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -3,8 +3,8 @@
 
 <head th:replace="~{common :: meta_header('貸出編集',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
-    <link rel="stylesheet" th:href="@{/css/rental/add.css}" />
-    <script type="text/javascript" th:src="@{/js/rental/add.js}"></script>
+    <link rel="stylesheet" th:href="@{/css/rental/edit.css}" />
+    <script type="text/javascript" th:src="@{/js/rental/edit.js}"></script>
 </head>
 
 <body>
@@ -20,7 +20,8 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}"
+                    method="post" novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -29,16 +31,26 @@
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
-                            </tr>
+                                <th class="header_days" th:colspan="${daysInMonth}"
+                                    th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             <tr class="days">
-                                <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
+                                <th th:each="day : ${daysOfWeek}" th:text="${day}"
+                                    th:classappend="${day.contains('土')} ? 'saturday' : (${day.contains('日')} ? 'sunday' : '')">
+                                </th>
+
                             </tr>
                         </thead>
+                        <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                            <tr th:each="stock: ${stocks}">
+                                <td th:text="${stock[0].title}"></td> <!-- 一つ目の値 -->
+                                <td th:text="${stock[0].stockCount}"></td> <!-- 二つ目の値 -->
+                                <td th:each="rentalstock : ${stock}">
+                                    <span th:if="${rentalstock.countAvailableRental le 0}" th:text="${'×'}"></span>
+                                    <a th:if="${rentalstock.countAvailableRental gt 0}"
+                                        th:href="@{/rental/add(stockId=${rentalstock.stockId}, expectedRentalOn=${#dates.format(rentalstock.expectedRentalOn, 'yyyy-MM-dd')})}"
+                                        th:text="${rentalstock.countAvailableRental}"></a>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/stock/index.html
+++ b/src/main/resources/templates/stock/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫一覧',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/index.css}" />
     <script type="text/javascript" th:src="@{/js/stock/index.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -14,7 +16,7 @@
                 <div class="page_title">在庫一覧</div>
                 <div class="add_btn">
                     <a th:href="@{/stock/add}">
-                        <span><img src="../images/icons/add.png" alt="add"/></span>
+                        <span><img src="../images/icons/add.png" alt="add" /></span>
                         <span>在庫登録</span>
                     </a>
                 </div>
@@ -30,13 +32,17 @@
                         <tr th:each="stock : ${stockList}" th:object="${stock}">
                             <td>
                                 <div class="stock_item_menu">
-                                    <div><a th:href="@{/stock/{id}/edit(id=*{id})}"><img src="../images/icons/edit.png" alt="edit"/></a></div>
-                                    <div><a href="#" class="" onClick="openDeleteModal()"><img src="../images/icons/trash.png" alt="trash"/></a></div>
+                                    <div><a th:href="@{/stock/{id}/edit(id=*{id})}"><img src="../images/icons/edit.png"
+                                                alt="edit" /></a></div>
+                                    <div><a href="#" class="" onClick="openDeleteModal()"><img
+                                                src="../images/icons/trash.png" alt="trash" /></a></div>
                                     <div><a th:href="@{/stock/{id}(id=*{id})}" th:text="*{id}"></a></div>
                                 </div>
                             </td>
                             <td th:text="*{bookMst.title}"></td>
-                            <td th:text="${stock.status == 0 && (#lists.isEmpty(stock.rentalManages) || stock.rentalManages[0].status != 1) ? '利用可' : '利用不可'}"></td>
+                            <td
+                                th:text="${stock.status == 0 && (#lists.isEmpty(stock.rentalManages) || stock.rentalManages[0].status != 1) ? '利用可' : '利用不可'}">
+                            </td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
**【概要】**
*在庫カレンダー機能の追加
*generatevalueメソッドで書籍名、在庫数、日ごとの貸出可能在庫数の処理
*Repositoryで書籍名、在庫数、貸出可能在庫数、在庫管理番号を取得するSQL文
*calendarDtoの作成
*calendarのHTMLの修正

**【テスト証跡】**
*在庫カレンダーの書籍名、在庫数、日ごとの貸出可能在庫数が正しく表示されているか
*貸出可能在庫数のリンクで貸出登録画面に遷移し、貸出予定日と在庫管理番号がセットされているか

以上を確認していただきたいです。よろしくお願いいたします。